### PR TITLE
Fix bid list generation bug

### DIFF
--- a/lib/five_hundred/bid.ex
+++ b/lib/five_hundred/bid.ex
@@ -36,7 +36,7 @@ defmodule FiveHundred.Bid do
   | Open Misere  | 500    |       |          |        |           |
   | Blind Misere | 1000   |       |          |        |           |
   """
-  def bids(), do: List.flatten(standard_bids(), special_bids())
+  def bids(), do: standard_bids() ++ special_bids()
 
   @spec standard_bids() :: [t()]
   @doc """


### PR DESCRIPTION
## Summary
- fix incorrect call to `List.flatten` when generating bid list

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842e270832c8324a4c16d776e57b066