### PR TITLE
Add trick info to decision log

### DIFF
--- a/lib/five_hundred_web/live/game_live.ex
+++ b/lib/five_hundred_web/live/game_live.ex
@@ -4,7 +4,7 @@ defmodule FiveHundredWeb.GameLive do
 
   alias FiveHundred.{Game, GameServer, Player, PlayerBid, Card, Bid}
   alias Phoenix.PubSub
-  import FiveHundred.Game, only: [display_card: 1]
+  import FiveHundred.Game, only: [display_card: 1, last_completed_trick: 1, decision_to_string: 2]
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/five_hundred_web/live/game_live.html.heex
+++ b/lib/five_hundred_web/live/game_live.html.heex
@@ -45,16 +45,36 @@
               <h3 class="text-lg font-semibold mb-2">Current Trick</h3>
               <div class="flex gap-4 p-4 bg-green-50 rounded min-h-[100px] items-center justify-center">
                 <%= for {card, i} <- Enum.with_index(@game.current_trick || []) do %>
+                  <% player_index = rem(@game.trick_leader + i, length(@game.players)) %>
                   <div class="text-center">
                     <div class={"card #{card_color(card)}"}>
                       <%= display_card(card) %>
                     </div>
                     <div class="text-sm mt-1">
-                      <%= Enum.at(@game.players, i).name %>
+                      <%= Enum.at(@game.players, player_index).name %>
                     </div>
                   </div>
                 <% end %>
               </div>
+
+              <% last = last_completed_trick(@game) %>
+              <%= if last do %>
+                <% {cards, leader} = last %>
+                <h3 class="text-lg font-semibold mb-2 mt-6">Previous Trick</h3>
+                <div class="flex gap-4 p-4 bg-yellow-50 rounded min-h-[100px] items-center justify-center">
+                  <%= for {card, i} <- Enum.with_index(cards) do %>
+                    <% p_index = rem(leader + i, length(@game.players)) %>
+                    <div class="text-center">
+                      <div class={"card #{card_color(card)}"}>
+                        <%= display_card(card) %>
+                      </div>
+                      <div class="text-sm mt-1">
+                        <%= Enum.at(@game.players, p_index).name %>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
             </div>
 
             <%= if Enum.at(@game.players, @game.turn).id == @player.id do %>
@@ -131,6 +151,17 @@
               <% end %>
             </div>
           </div>
+
+          <%= if @game.decisions != [] do %>
+            <div class="mt-6">
+              <h3 class="text-lg font-semibold mb-2">Game Log</h3>
+              <ul class="text-sm space-y-1 list-disc list-inside">
+                <%= for decision <- Enum.take(Enum.reverse(@game.decisions), 10) do %>
+                  <li><%= decision_to_string(@game, decision) %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
         <% else %>
           <p class="text-gray-600">Loading game state...</p>
         <% end %>

--- a/lib/five_hundred_web/live/play_live.ex
+++ b/lib/five_hundred_web/live/play_live.ex
@@ -3,6 +3,7 @@ defmodule FiveHundredWeb.PlayLive do
   require Logger
   alias Phoenix.PubSub
   alias FiveHundred.{Game, GameServer, PlayerBid, Card, Bid}
+  import FiveHundred.Game, only: [last_completed_trick: 1, decision_to_string: 2]
 
   @impl true
   def mount(%{"game" => game_code} = _params, %{"user_id" => user_id} = _session, socket) do

--- a/lib/five_hundred_web/live/play_live.html.heex
+++ b/lib/five_hundred_web/live/play_live.html.heex
@@ -124,18 +124,40 @@
               <h3 class="text-lg font-semibold mb-2">Current Trick</h3>
               <div class="flex gap-4 p-4 bg-green-50 rounded min-h-[100px] items-center justify-center">
                 <%= for {card, i} <- Enum.with_index(@game.current_trick || []) do %>
+                  <% player_index = rem(@game.trick_leader + i, length(@game.players)) %>
                   <div class="text-center">
                     <div class="inline-block">
                       <div class={"card #{card_color(card)}"}>
                         <%= display_card(card) %>
                       </div>
                       <div class="text-sm mt-1 text-gray-600">
-                        <%= Enum.at(@game.players, i).name %>
+                        <%= Enum.at(@game.players, player_index).name %>
                       </div>
                     </div>
                   </div>
                 <% end %>
               </div>
+
+              <% last = last_completed_trick(@game) %>
+              <%= if last do %>
+                <% {cards, leader} = last %>
+                <h3 class="text-lg font-semibold mb-2 mt-6">Previous Trick</h3>
+                <div class="flex gap-4 p-4 bg-yellow-50 rounded min-h-[100px] items-center justify-center">
+                  <%= for {card, i} <- Enum.with_index(cards) do %>
+                    <% p_index = rem(leader + i, length(@game.players)) %>
+                    <div class="text-center">
+                      <div class="inline-block">
+                        <div class={"card #{card_color(card)}"}>
+                          <%= display_card(card) %>
+                        </div>
+                        <div class="text-sm mt-1 text-gray-600">
+                          <%= Enum.at(@game.players, p_index).name %>
+                        </div>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
             </div>
 
             <div class="mt-6">
@@ -240,6 +262,17 @@
               <% end %>
             </div>
           </div>
+
+          <%= if @game.decisions != [] do %>
+            <div class="mt-6">
+              <h3 class="text-lg font-semibold mb-2">Game Log</h3>
+              <ul class="text-sm space-y-1 list-disc list-inside">
+                <%= for decision <- Enum.take(Enum.reverse(@game.decisions), 10) do %>
+                  <li><%= decision_to_string(@game, decision) %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary
- extend decisions with structured trick_complete entries
- derive previous trick from decision log in LiveViews
- render game log with helper for decision formatting

## Testing
- `mix format` *(fails: could not download OTP build)*
- `mix compile` *(fails: could not download OTP build)*

------
https://chatgpt.com/codex/tasks/task_e_684431b46f9883249558e93b9bc60412