### PR TITLE
Add score displays

### DIFF
--- a/lib/five_hundred_web/live/game_live.html.heex
+++ b/lib/five_hundred_web/live/game_live.html.heex
@@ -96,7 +96,21 @@
               <div class="bg-gray-50 p-4 rounded">
                 <p>Trump Suit: <%= Card.to_string(@game.winning_bid.bid.suit) %></p>
                 <p>Contract: <%= @game.winning_bid.bid.tricks %> tricks by <%= Enum.at(@game.players, @game.winning_bid.player_index).name %></p>
+                <p>Expected Score: <%= @game.winning_bid.bid.points %> points</p>
                 <p>Tricks Won: <%= Map.get(@game, :tricks_won, 0) %></p>
+                <div class="mt-4">
+                  <h4 class="font-semibold">Team Scores:</h4>
+                  <div class="grid grid-cols-2 gap-4">
+                    <div>
+                      <p>Team 1 (Players 1,3): <%= @game.team_scores[0] %></p>
+                      <p class="text-sm text-gray-600">Needed for 500: <%= 500 - @game.team_scores[0] %></p>
+                    </div>
+                    <div>
+                      <p>Team 2 (Players 2,4): <%= @game.team_scores[1] %></p>
+                      <p class="text-sm text-gray-600">Needed for 500: <%= 500 - @game.team_scores[1] %></p>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           <% end %>

--- a/lib/five_hundred_web/live/play_live.html.heex
+++ b/lib/five_hundred_web/live/play_live.html.heex
@@ -183,6 +183,7 @@
               <div class="bg-gray-50 p-4 rounded">
                 <p>Trump Suit: <%= Card.to_string(@game.winning_bid.bid.suit) %></p>
                 <p>Contract: <%= @game.winning_bid.bid.tricks %> tricks by <%= Enum.at(@game.players, @game.winning_bid.player_index).name %></p>
+                <p>Expected Score: <%= @game.winning_bid.bid.points %> points</p>
 
                 <div class="mt-4">
                   <h4 class="font-semibold">Team Scores:</h4>
@@ -190,10 +191,12 @@
                     <div>
                       <p>Team 1 (Players 1,3): <%= @game.team_scores[0] %></p>
                       <p class="text-sm text-gray-600">Tricks this round: <%= @game.tricks_per_team[0] %> (<%= @game.tricks_per_team[0] * 10 %> points)</p>
+                      <p class="text-sm text-gray-600">Needed for 500: <%= 500 - @game.team_scores[0] %></p>
                     </div>
                     <div>
                       <p>Team 2 (Players 2,4): <%= @game.team_scores[1] %></p>
                       <p class="text-sm text-gray-600">Tricks this round: <%= @game.tricks_per_team[1] %> (<%= @game.tricks_per_team[1] * 10 %> points)</p>
+                      <p class="text-sm text-gray-600">Needed for 500: <%= 500 - @game.team_scores[1] %></p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- show expected score for winning bid in round
- show each team score and remaining points to hit 500

## Testing
- `mix local.hex --force` *(fails: bad status code 503)*
- `mix compile` *(fails: requires hex)*

------
https://chatgpt.com/codex/tasks/task_e_6844470c715c8324b3c4473af3720c55